### PR TITLE
Whitelist what files are published on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "test": "ava",
     "sample": "node sample"
   },
+  "files": [
+    "src/",
+    "eleventy-cache-assets.js"
+  ],
   "engines": {
     "node": ">=10"
   },


### PR DESCRIPTION
Currently when I install this package, unnecessary files like tests and samples are downloaded too.
```
npm notice === Tarball Contents ===
npm notice 4.3kB src/AssetCache.js
npm notice 552B  test/AssetCacheTest.js
npm notice 1.7kB eleventy-cache-assets.js
npm notice 1.0kB test/QueueTest.js
npm notice 2.7kB src/RemoteAssetCache.js
npm notice 2.6kB test/RemoteAssetCacheTest.js
npm notice 1.4kB sample.js
npm notice 1.1kB package.json
npm notice 2.2kB README.md
npm notice === Tarball Details ===
npm notice name:          @11ty/eleventy-cache-assets
npm notice version:       2.1.0
npm notice filename:      11ty-eleventy-cache-assets-2.1.0.tgz
npm notice package size:  5.7 kB
npm notice unpacked size: 17.5 kB
npm notice shasum:        fda6c0a0dc6eacc19f2574a93171a890f2d53ac4
npm notice integrity:     sha512-Tn0ErySHDbKIL[...]vcX4+egpuNfJg==
npm notice total files:   9
```

This is a bit redundant as nobody uses these files when it's used as a dependency. So what we can do is whitelist what files are published using ["files" field](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files) in `package.json`.

So now, only files that actually used are downloaded.
```
npm notice === Tarball Contents ===
npm notice 4.3kB src/AssetCache.js
npm notice 1.7kB eleventy-cache-assets.js
npm notice 2.7kB src/RemoteAssetCache.js
npm notice 1.2kB package.json
npm notice 2.2kB README.md
npm notice === Tarball Details ===
npm notice name:          @11ty/eleventy-cache-assets
npm notice version:       2.1.0
npm notice filename:      11ty-eleventy-cache-assets-2.1.0.tgz
npm notice package size:  4.3 kB
npm notice unpacked size: 12.0 kB
npm notice shasum:        bb4eeae9d371e982e235aaebbd56c85fc148f48e
npm notice integrity:     sha512-mEvzymH4G7aBB[...]98gj4IW/sZsHA==
npm notice total files:   5
```